### PR TITLE
Feedbacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Deploy custom monitors from YAML configuration files.
 ## Script execution
 
 ```bash
-go run ./.. sample_config.yaml
+go run ./... sample_config.yaml
 ```
 
 ## Installation


### PR DESCRIPTION
# Why
Based on feedbacks:
- we don't print stack trace w/ errors
- we print information about complete deploy in the end when it is success
- fix command to run app in doc