### PR TITLE
Namespace instead of configId.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,6 @@ monitors:
 
 - `monitored_id` and `monitored_ids` cannot be used together
 - At least one of `monitored_id` or `monitored_ids` must be specified
-- Monitor `id` must be unique across all monitors (across all configs)
+- Monitor `id` must be unique across all monitors (across all namespaces)
 - `time_partitioning` is required for all monitors
 - Only one schedule type (`daily` or `hourly`) can be specified per monitor

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ SYNQ_CLIENT_SECRET=your_client_secret
 ## YAML Format
 
 ```yaml
-config_id: "data-team-pipeline"
+namespace: "data-team-pipeline"
 
 defaults:
   severity: ERROR
@@ -151,7 +151,7 @@ monitors:
 
 | Field       | Type   | Required | Default | Description                             |
 | ----------- | ------ | -------- | ------- | --------------------------------------- |
-| `config_id` | string | ❌       | -       | Unique identifier for the configuration |
+| `namespace` | string | ❌       | -       | Unique identifier for the configuration |
 | `defaults`  | object | ❌       | -       | Default values applied to all monitors  |
 | `monitors`  | array  | ✅       | -       | Array of monitor definitions            |
 
@@ -182,7 +182,7 @@ monitors:
 | `time_partitioning`  | string        | ✅       | `{defaults.time_partitioning}` | Time partitioning expression                                           |
 | `mode`               | object        | ❌       | `{defaults.mode}`              | Detection mode configuration                                           |
 | `schedule`           | object        | ❌       | `{defaults.schedule}`          | Schedule configuration                                                 |
-| `config_id`          | string        | ❌       | `{config_id}`                  | Override default config ID                                             |
+| `namespace`          | string        | ❌       | `{namespace}`                  | Override default namespace ID                                          |
 
 ### Mode Configuration
 

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -1,4 +1,4 @@
-config_id: "data-team-pipeline"
+namespace: "data-team-pipeline"
 
 defaults:
   severity: ERROR

--- a/yaml/parser.go
+++ b/yaml/parser.go
@@ -344,7 +344,7 @@ func parseSensitivity(sensitivity string) (pb.Sensitivity, bool) {
 // GetYAMLSummary provides a summary of the YAML configuration
 func GetYAMLSummary(config *YAMLConfig) map[string]interface{} {
 	summary := make(map[string]interface{})
-	summary["config_id"] = config.ConfigID
+	summary["namespace"] = config.ConfigID
 	summary["monitors_count"] = len(config.Monitors)
 
 	if config.Defaults.Severity != "" {

--- a/yaml/types.go
+++ b/yaml/types.go
@@ -7,7 +7,7 @@ import (
 
 // YAMLConfig represents the YAML file structure
 type YAMLConfig struct {
-	ConfigID string `yaml:"config_id"`
+	ConfigID string `yaml:"namespace"`
 	Defaults struct {
 		Severity         string        `yaml:"severity,omitempty"`
 		TimePartitioning string        `yaml:"time_partitioning,omitempty"`
@@ -33,7 +33,7 @@ type YAMLMonitor struct {
 	TimePartitioning  string        `yaml:"time_partitioning,omitempty"`
 	Mode              *YAMLMode     `yaml:"mode,omitempty"`
 	Schedule          *YAMLSchedule `yaml:"schedule,omitempty"`
-	ConfigID          string        `yaml:"config_id,omitempty"`
+	ConfigID          string        `yaml:"namespace,omitempty"`
 }
 
 // YAMLMode represents mode configuration in YAML


### PR DESCRIPTION
# Why
Rename `config_id` to `namespace`.